### PR TITLE
Pin to Flask==0.10.1

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -4,4 +4,4 @@ from .flask_init import init_app, init_manager
 import flask_featureflags  # noqa
 
 
-__version__ = '36.5.0'
+__version__ = '36.5.1'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
          'Flask-FeatureFlags==0.6',
          'Flask-Script==2.0.5',
          'Flask-WTF==0.14.2',
-         'Flask>=0.10.1',
+         'Flask==0.10.1',
          'Flask-Login>=0.2.11',
          'boto3==1.4.8',
          'contextlib2==0.4.0',


### PR DESCRIPTION
 ## Summary
Our frontend apps all depend on Flask v0.10.1 specifically, but this
repository doesn't. Flask released v1.0.0 over the weekend and this is
trying to pull it in now, which breaks things. Let's pin this dependency
to the specific version and review if/how/when/whether we should upgrade
to Flask v1.0.0