### PR TITLE
Allow query parameters for mailchimp list members

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '59.1.1'
+__version__ = '59.2.0'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -183,12 +183,20 @@ class DMMailChimpClient(object):
                     success = False
         return success
 
-    def get_email_addresses_from_list(self, list_id: str, pagination_size: int = 100) -> Iterator[str]:
+    def get_email_addresses_from_list(
+            self,
+            list_id: str,
+            pagination_size: int = 100,
+            **query_parameters,
+    ) -> Iterator[str]:
+        """
+        See https://mailchimp.com/developer/marketing/api/list-members/list-members-info/ for possible query parameters.
+        """
         offset = 0
         while True:
             member_data = self.timeout_retry(
                 self._client.lists.members.all
-            )(list_id, count=pagination_size, offset=offset)
+            )(list_id, count=pagination_size, offset=offset, **query_parameters)
             if not member_data.get("members", None):
                 break
             offset += pagination_size

--- a/tests/email/test_dm_mailchimp.py
+++ b/tests/email/test_dm_mailchimp.py
@@ -2,6 +2,8 @@
 """Tests for the Digital Marketplace MailChimp integration."""
 import logging
 from unittest import mock
+from unittest.mock import ANY
+
 import pytest
 import types
 
@@ -481,6 +483,16 @@ class TestMailchimp(PatchExternalServiceLogConditionMixin):
                 mock.call('a_list_id', count=100, offset=0),
                 mock.call('a_list_id', count=100, offset=100),
             ]
+
+    def test_passes_through_query_parameters(self):
+        dm_mailchimp_client = DMMailChimpClient(
+            'username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp')
+        )
+        with mock.patch.object(dm_mailchimp_client._client.lists.members, 'all', autospec=True) as all_members:
+            all_members.side_effect = [{"members": []}]
+            list(dm_mailchimp_client.get_email_addresses_from_list('a_list_id', foo="bar"))
+
+        assert all_members.mock_calls == [mock.call(ANY, count=ANY, offset=ANY, foo="bar")]
 
     def test_offset_increments_until_no_members(self):
         dm_mailchimp_client = DMMailChimpClient('username', DUMMY_MAILCHIMP_API_KEY, logging.getLogger('mailchimp'))


### PR DESCRIPTION
https://trello.com/c/xkosxLyt/128-2-automatically-extract-the-correct-set-of-emails-from-mailchimp

We have a method for getting an iterator of email addresses that belong to a list. We want to start using this method in a more restrictive way - e.g. limiting to status='subscribed'. Rather than try to anticipate all query parameters we might want, let users specify parameters freely and let the mailchimp API decide whether they're OK or not.

Will unblock work to script getting emails for the 'framework coming' email.