### PR TITLE
Stop using custom www_authenticate handling logic

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.0.0'
+__version__ = '60.1.0'

--- a/dmutils/authentication.py
+++ b/dmutils/authentication.py
@@ -3,23 +3,10 @@ from werkzeug.exceptions import Unauthorized
 
 class UnauthorizedWWWAuthenticate(Unauthorized):
     """
-    This is a near verbatim copy of an improvement to an as-yet-unreleased upstream version of werkzeug that allows
-    us to specify a www_authenticate argument containing the contents of that field. We should get rid of this once
-    we're able to upgrade past that version.
-
-    From werkzeug 8ed5b3f9a285eca756c3ab33f8c370a88eab3842
+    This class exists for back-compatibility. We originally needed it to add support for `www_authenticate` before
+    werkzeug added it to Unauthorized. Users should switch to use Unauthorized directly.
     """
     def __init__(self, www_authenticate=None, description=None):
-        super().__init__(description=description)
         if not isinstance(www_authenticate, (tuple, list)):
             www_authenticate = (www_authenticate,)
-        self.www_authenticate = www_authenticate
-
-    def get_headers(self, environ=None):
-        headers = super().get_headers(environ)
-        if self.www_authenticate:
-            headers.append((
-                'WWW-Authenticate',
-                ', '.join([str(x) for x in self.www_authenticate])
-            ))
-        return headers
+        super().__init__(description=description, www_authenticate=www_authenticate)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     install_requires=[
          'Flask-WTF>=0.14.2',
-         'Flask~=1.0',
+         'Flask>=1.0,<2.1',
          'Flask-gzip>=0.2',
          'Flask-Login>=0.2.11',
          'Flask-Session>=0.3.2',

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -276,14 +276,17 @@ def test_api_validation_error_handler(app_with_mocked_logger):
 def test_api_unauth(app_with_mocked_logger):
     with app_with_mocked_logger.test_request_context('/'):
         try:
-            raise UnauthorizedWWWAuthenticate(www_authenticate="lemur", description="Bogeyman's trick")
+            raise UnauthorizedWWWAuthenticate(
+                www_authenticate="Bearer realm=foo",
+                description="Unauthorized; bearer token must be provided",
+            )
         except UnauthorizedWWWAuthenticate as e:
             response = json_error_handler(e)
             assert json.loads(response.get_data()) == {
-                "error": "Bogeyman's trick",
+                "error": "Unauthorized; bearer token must be provided",
             }
             assert response.status_code == 401
-            assert response.headers["www-authenticate"] == "lemur"
+            assert response.headers["www-authenticate"] == "Bearer realm=foo"
             assert app_with_mocked_logger.logger.warning.mock_calls == []
 
 


### PR DESCRIPTION
https://trello.com/c/oWvOqn00/2276-upgrade-to-flask-v2

Werkzeug added this functionality in 0.15.0. We're currently using Werkzeug 1.0.1. So we can safely retire our custom logic. The test shows that this does not change the bahaviour we rely on.

This allows us to add support for Flask 2.0. The tests now all pass. Note there are deprecation warnings with Flask 2.0 that will become errors in 2.1. We cannot fix them (and thus add support for 2.1) until we drop support for 1.0.