### PR TITLE
Log reason for CSRF failure

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.1.0'
+__version__ = '60.1.1'

--- a/dmutils/errors/frontend.py
+++ b/dmutils/errors/frontend.py
@@ -21,11 +21,11 @@ def csrf_handler(csrf_error):
         )
     elif 'user_id' not in session:
         current_app.logger.info(
-            u'csrf.session_expired: Redirecting user to log in page'
+            'csrf.session_expired: Redirecting user to log in page'
         )
     else:
         current_app.logger.info(
-            u'csrf.invalid_token: Aborting request, user_id: {user_id}',
+            'csrf.invalid_token: Aborting request, user_id: {user_id}',
             extra={'user_id': session['user_id']}
         )
 

--- a/dmutils/errors/frontend.py
+++ b/dmutils/errors/frontend.py
@@ -21,12 +21,13 @@ def csrf_handler(csrf_error):
         )
     elif 'user_id' not in session:
         current_app.logger.info(
-            'csrf.session_expired: Redirecting user to log in page'
+            'csrf.session_expired: Redirecting user to log in page',
+            extra={'error': csrf_error.description},
         )
     else:
         current_app.logger.info(
             'csrf.invalid_token: Aborting request, user_id: {user_id}',
-            extra={'user_id': session['user_id']}
+            extra={'user_id': session['user_id'], 'error': csrf_error.description}
         )
 
     flash('Your session has expired. Please log in again.', "error")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -35,18 +35,21 @@ def test_csrf_handler_redirects_to_login(user_session, app, cookie_probe_expect_
             # Our user is logged in
             session['user_id'] = 1234
 
-        response = csrf_handler(CSRFError())
+        response = csrf_handler(CSRFError('reason'))
 
         assert response.status_code == 302
         assert response.location == '/user/login?next=%2F'
 
         if user_session:
             assert app.logger.info.call_args_list == [
-                mock.call('csrf.invalid_token: Aborting request, user_id: {user_id}', extra={'user_id': 1234})
+                mock.call(
+                    'csrf.invalid_token: Aborting request, user_id: {user_id}',
+                    extra={'user_id': 1234, 'error': 'reason'},
+                )
             ]
         else:
             assert app.logger.info.call_args_list == [
-                mock.call('csrf.session_expired: Redirecting user to log in page')
+                mock.call('csrf.session_expired: Redirecting user to log in page', extra={'error': 'reason'})
             ]
 
 


### PR DESCRIPTION
https://trello.com/c/LhxN5XkG/206-nft-environment-domain-issue

In one of our new environments, we're seeing unexpected CSRF failures. It would be helpful to have the reason for the failure included in the log to help us debug.
