### PR TITLE
Add 400 error exception and new handling

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.2.0'
+__version__ = '60.3.0'

--- a/dmutils/email/dm_notify.py
+++ b/dmutils/email/dm_notify.py
@@ -8,7 +8,7 @@ from flask import current_app
 from notifications_python_client import NotificationsAPIClient
 from notifications_python_client.errors import HTTPError
 
-from dmutils.email.exceptions import EmailError, EmailTemplateError
+from dmutils.email.exceptions import EmailError, EmailTemplateError, EmailInvalidError
 from dmutils.email.helpers import hash_string
 from dmutils.timing import logged_duration_for_external_request as log_external_request
 
@@ -201,6 +201,11 @@ class DMNotifyClient:
             if isinstance(e.message, list) and \
                     any(msg["message"].startswith("Missing personalisation") for msg in e.message):
                 raise EmailTemplateError(str(e))
+
+            if isinstance(e.message, list) and \
+                    any(msg["message"].startswith("email_address Not a valid email address") for msg in e.message):
+                raise EmailInvalidError(str(e))
+
             raise EmailError(str(e))
 
         self._log(logging.INFO, f"Email with reference '{reference}' sent to Notify successfully", email_obj)

--- a/dmutils/email/exceptions.py
+++ b/dmutils/email/exceptions.py
@@ -8,3 +8,7 @@ class EmailError(Exception):
 
 class EmailTemplateError(EmailError):
     pass
+
+
+class EmailInvalidError(EmailError):
+    pass

--- a/tests/email/test_dm_notify.py
+++ b/tests/email/test_dm_notify.py
@@ -10,7 +10,7 @@ from itertools import product
 import pytest
 from notifications_python_client.errors import HTTPError
 
-from dmutils.email.exceptions import EmailError, EmailTemplateError
+from dmutils.email.exceptions import EmailError, EmailTemplateError, EmailInvalidError
 from dmutils.email.dm_notify import DMNotifyClient
 from helpers import PatchExternalServiceLogConditionMixin, assert_external_service_log_entry
 
@@ -504,6 +504,17 @@ class TestDMNotifyClient(PatchExternalServiceLogConditionMixin):
             email_mock.side_effect = notify_example_http_error
 
             with pytest.raises(EmailError):
+                dm_notify_client.send_email(self.email_address, self.template_id)
+
+    def test_raises_email_invalid_error_if_email_invalid(self, dm_notify_client, notify_example_http_error):
+        notify_example_http_error._message = [
+            {'error': 'ValidationError', 'message': 'email_address Not a valid email address'}
+        ]
+
+        with mock.patch(self.client_class_str + '.' + 'send_email_notification') as email_mock:
+            email_mock.side_effect = notify_example_http_error
+
+            with pytest.raises(EmailInvalidError):
                 dm_notify_client.send_email(self.email_address, self.template_id)
 
     def test_raises_email_template_error_if_personalisation_missing(self, dm_notify_client, notify_example_http_error):


### PR DESCRIPTION
https://trello.com/c/qHECZyQh/215-fix-issue-with-notification-job-when-there-is-an-invalid-email

When an invalid email is provided to the mail wrapper, a 400 error is raised and thrown preventing the mailing job to continue. This script adjust adds in a new error to raise for the event when an invalid email is provided, in order to continue processing the remaining emails.