### PR TITLE
Add support for arbitrary marketplace.team environments

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.4.0'
+__version__ = '60.5.0'

--- a/dmutils/env_helpers.py
+++ b/dmutils/env_helpers.py
@@ -1,7 +1,7 @@
 import os
 
 
-def get_api_endpoint_from_stage(stage, app='api'):
+def get_api_endpoint_from_stage(stage: str, app: str = 'api') -> str:
     """Return the full URL of given API or Search API environment.
 
     :param stage: environment name. Can be 'production', 'dev' (aliases: 'local', 'development'), 'staging', 'preview',
@@ -23,7 +23,7 @@ def get_api_endpoint_from_stage(stage, app='api'):
     return f'https://{app}.{stage}.marketplace.team'
 
 
-def get_web_url_from_stage(stage):
+def get_web_url_from_stage(stage: str) -> str:
     """Return the full URL of given web environment.
 
     :param stage: environment name. Can be 'production', 'dev' (aliases: 'local', 'development'), 'staging', 'preview',
@@ -37,7 +37,7 @@ def get_web_url_from_stage(stage):
     return f'https://www.{stage}.marketplace.team'
 
 
-def get_assets_endpoint_from_stage(stage):
+def get_assets_endpoint_from_stage(stage: str) -> str:
     if stage in ['local', 'dev', 'development']:
         # Static files are not served via nginx for local environments
         raise NotImplementedError()

--- a/dmutils/env_helpers.py
+++ b/dmutils/env_helpers.py
@@ -4,20 +4,11 @@ import os
 def get_api_endpoint_from_stage(stage, app='api'):
     """Return the full URL of given API or Search API environment.
 
-    :param stage: environment name. Can be one of 'preview', 'staging',
-                  'production' or 'dev' (aliases: 'local', 'development').
+    :param stage: environment name. Can be 'production', 'dev' (aliases: 'local', 'development'), 'staging', 'preview',
+                  or the name of any other environment
     :param app: should be either 'api' or 'search-api'
 
     """
-
-    stage_domains = {
-        'preview': 'https://{}.preview.marketplace.team'.format(app),
-        'staging': 'https://{}.staging.marketplace.team'.format(app),
-        'production': 'https://{}.digitalmarketplace.service.gov.uk'.format(app),
-        'nft': 'https://{}.nft.marketplace.team'.format(app),
-        'uat': 'https://{}.uat.marketplace.team'.format(app),
-    }
-
     dev_ports = {
         "api": os.getenv("DM_API_PORT", 5000),
         "search-api": os.getenv("DM_SEARCH_API_PORT", 5009),
@@ -26,27 +17,24 @@ def get_api_endpoint_from_stage(stage, app='api'):
 
     if stage in ['local', 'dev', 'development']:
         return 'http://localhost:{}'.format(dev_ports[app])
+    elif stage == "production":
+        return f'https://{app}.digitalmarketplace.service.gov.uk'
 
-    return stage_domains[stage]
+    return f'https://{app}.{stage}.marketplace.team'
 
 
 def get_web_url_from_stage(stage):
     """Return the full URL of given web environment.
 
-    :param stage: environment name. Can be one of 'preview', 'staging',
-                  'production' or 'dev' (aliases: 'local', 'development').
+    :param stage: environment name. Can be 'production', 'dev' (aliases: 'local', 'development'), 'staging', 'preview',
+                  or the name of any other environment
     """
     if stage in ['local', 'dev', 'development']:
         return 'http://localhost'
+    elif stage == "production":
+        return 'https://www.digitalmarketplace.service.gov.uk'
 
-    stage_domains = {
-        'preview': 'https://www.preview.marketplace.team',
-        'staging': 'https://www.staging.marketplace.team',
-        'production': 'https://www.digitalmarketplace.service.gov.uk',
-        'nft': 'https://www.nft.marketplace.team',
-        'uat': 'https://www.uat.marketplace.team',
-    }
-    return stage_domains[stage]
+    return f'https://www.{stage}.marketplace.team'
 
 
 def get_assets_endpoint_from_stage(stage):


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/OST-114

We're starting to get a much larger number of such environments - currently 4, soon to rise to 5.

Rather than have to explicitly add support for each new environment, it would be much easier to assume that the naming convention we've used thus far is going to continue.

Related to https://github.com/Crown-Commercial-Service/digitalmarketplace-scripts/pull/745