### PR TITLE
Hide DOS6 banner once it's closed

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.6.0'
+__version__ = '60.7.0'

--- a/dmutils/dmp_so_status.py
+++ b/dmutils/dmp_so_status.py
@@ -1,7 +1,8 @@
-from datetime import date
+from datetime import datetime
 
-DMP_SO_GO_LIVE_DATE = '2022-01-14'
+DOS6_OPEN = datetime(2022, 1, 14, 12, 0, 0)
+DOS6_CLOSE = datetime(2022, 2, 24, 15, 0, 0)
 
 
 def are_new_frameworks_live(params) -> bool:
-    return date.today().strftime('%Y-%m-%d') >= DMP_SO_GO_LIVE_DATE or params.get('show_dmp_so_banner') == 'true'
+    return DOS6_OPEN <= datetime.now() <= DOS6_CLOSE or params.get('show_dmp_so_banner') == 'true'

--- a/tests/test_dmp_so_status.py
+++ b/tests/test_dmp_so_status.py
@@ -8,7 +8,7 @@ def test_should_be_false_if_before_go_live_date():
     assert are_new_frameworks_live({}) is False
 
 
-@freeze_time('2022-01-14')
+@freeze_time('2022-01-14 12:00:01')
 def test_should_be_true_if_on_go_live_date():
     assert are_new_frameworks_live({}) is True
 
@@ -25,4 +25,9 @@ def test_should_be_true_if_before_date_and_go_live_param():
 
 @freeze_time('2022-01-04')
 def test_should_be_false_if_before_date_and_not_go_live_param():
+    assert are_new_frameworks_live({'show_dmp_1.0_banner': 'true'}) is False
+
+
+@freeze_time('2022-02-24 15:00:01')
+def test_should_be_false_after_dos6_closes():
     assert are_new_frameworks_live({'show_dmp_1.0_banner': 'true'}) is False


### PR DESCRIPTION
https://crowncommercialservice.atlassian.net/browse/OST-508

We think it's best to remove the banner in this period. Telling users something is coming soon and giving a link that they cannot use might cause confusion. Sometimes giving information when a user wouldn't normally be looking for it (out of context) can raise more questions than answers.

Enhance the logic to work on datetimes so we can show/hide the banner at specific times (rather than midnight).

We'll need to rework this for G13 - I'm not doing that now because I don't know the equivalent dates for G13.