### PR TITLE
Handle removed email race condition

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.7.1'
+__version__ = '60.8.0'

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -229,8 +229,7 @@ class DMMailChimpClient(object):
                 )
             return True
         except (RequestException, MailChimpError) as e:
-            self.logger.error(
+            self.logger.exception(
                 f"Mailchimp failed to permanently remove user ({hashed_email}) from list ({list_id})",
-                extra={"error": str(e), "mailchimp_response": get_response_from_exception(e)},
             )
         return False

--- a/dmutils/email/dm_mailchimp.py
+++ b/dmutils/email/dm_mailchimp.py
@@ -229,6 +229,9 @@ class DMMailChimpClient(object):
                 )
             return True
         except (RequestException, MailChimpError) as e:
+            if get_response_from_exception(e).get('status') == 404:
+                self.logger.info(f"User ({hashed_email}) not found in list ({list_id})")
+                return True
             self.logger.exception(
                 f"Mailchimp failed to permanently remove user ({hashed_email}) from list ({list_id})",
             )


### PR DESCRIPTION
Now that we've got two environments (1.5 and 1.0), we're running the data retention script for both. The environments have different databases, but share Mailchimp lists. This means that we have the potential for race conditions - one environment's job can delete a user from a list before the other tries to.

When this happens, we get a MailChimpError with a status of 404. So count this particular circumstance as a success.

Also improve logging for this particular method so it is more useful when run from a script.

Should prevent a recurrence of https://ci.marketplace.team/job/data-retention-production/1376/