### PR TITLE
Increase the minimum version of notifications-python-client to 5.7.1

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.8.0'
+__version__ = '60.8.1'

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
          'requests>=2.22.0,<3',
          'redis>=3.5.2',
          'fleep<1.1,>=1.0.1',
-         'notifications-python-client>=5.0.1,<7.0.0',
+         'notifications-python-client>=5.7.1,<7.0.0',
          'odfpy>=1.3.6',
          'python-json-logger>=0.1.11,<3.0.0',
          'pytz',


### PR DESCRIPTION
This is to fix an issue where apps using dmutils do not have a version of `notifications-python-client` that is compatible with recent updates to `pyjwt`.

After this is done, we'll need to patch all of the projects to use the latest version of DM utils