### PR TITLE
Update banner and tests

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.8.1'
+__version__ = '60.9.0'

--- a/dmutils/dmp_so_status.py
+++ b/dmutils/dmp_so_status.py
@@ -5,4 +5,5 @@ G13_CLOSE = datetime(2022, 5, 18, 15, 0, 0)
 
 
 def are_new_frameworks_live(_params) -> bool:
+    # return G13_OPEN <= datetime.now() <= G13_CLOSE or params.get('show_dmp_so_banner') == 'true'
     return True

--- a/dmutils/dmp_so_status.py
+++ b/dmutils/dmp_so_status.py
@@ -4,5 +4,5 @@ G13_OPEN = datetime(2022, 3, 9, 10, 0, 0)
 G13_CLOSE = datetime(2022, 5, 18, 15, 0, 0)
 
 
-def are_new_frameworks_live(params) -> bool:
-    return G13_OPEN <= datetime.now() <= G13_CLOSE or params.get('show_dmp_so_banner') == 'true'
+def are_new_frameworks_live(_params) -> bool:
+    return True

--- a/tests/test_dmp_so_status.py
+++ b/tests/test_dmp_so_status.py
@@ -2,6 +2,7 @@
 
 from dmutils.dmp_so_status import are_new_frameworks_live
 
+
 def test_should_be_true():
     assert are_new_frameworks_live({}) is True
 

--- a/tests/test_dmp_so_status.py
+++ b/tests/test_dmp_so_status.py
@@ -1,33 +1,35 @@
-from freezegun import freeze_time
+# from freezegun import freeze_time
 
 from dmutils.dmp_so_status import are_new_frameworks_live
 
-
-@freeze_time('2022-03-08')
-def test_should_be_false_if_before_go_live_date():
-    assert are_new_frameworks_live({}) is False
-
-
-@freeze_time('2022-03-09 12:00:01')
-def test_should_be_true_if_on_go_live_date():
+def test_should_be_true():
     assert are_new_frameworks_live({}) is True
 
-
-@freeze_time('2022-03-10')
-def test_should_be_true_if_after_go_live_date():
-    assert are_new_frameworks_live({}) is True
-
-
-@freeze_time('2022-03-08')
-def test_should_be_true_if_before_date_and_go_live_param():
-    assert are_new_frameworks_live({'show_dmp_so_banner': 'true'}) is True
+# @freeze_time('2022-03-08')
+# def test_should_be_false_if_before_go_live_date():
+#     assert are_new_frameworks_live({}) is False
 
 
-@freeze_time('2022-03-08')
-def test_should_be_false_if_before_date_and_not_go_live_param():
-    assert are_new_frameworks_live({'show_dmp_1.0_banner': 'true'}) is False
+# @freeze_time('2022-03-09 12:00:01')
+# def test_should_be_true_if_on_go_live_date():
+#     assert are_new_frameworks_live({}) is True
 
 
-@freeze_time('2022-05-18 15:00:01')
-def test_should_be_false_after_g13_closes():
-    assert are_new_frameworks_live({'show_dmp_1.0_banner': 'true'}) is False
+# @freeze_time('2022-03-10')
+# def test_should_be_true_if_after_go_live_date():
+#     assert are_new_frameworks_live({}) is True
+
+
+# @freeze_time('2022-03-08')
+# def test_should_be_true_if_before_date_and_go_live_param():
+#     assert are_new_frameworks_live({'show_dmp_so_banner': 'true'}) is True
+
+
+# @freeze_time('2022-03-08')
+# def test_should_be_false_if_before_date_and_not_go_live_param():
+#     assert are_new_frameworks_live({'show_dmp_1.0_banner': 'true'}) is False
+
+
+# @freeze_time('2022-05-18 15:00:01')
+# def test_should_be_false_after_g13_closes():
+#     assert are_new_frameworks_live({'show_dmp_1.0_banner': 'true'}) is False


### PR DESCRIPTION
- Update Banner for new framework information and link to live dates.
- Always enable banner, temporarily.
- Updates tests for enabled banner and framework is not live.