### PR TITLE
Use AWS CLI for getting a presigned URL

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -2,4 +2,4 @@ from . import config, formats, logging, proxy_fix, request_id
 from .flask_init import init_app
 
 
-__version__ = '60.11.1'
+__version__ = '60.12.0'


### PR DESCRIPTION
Because we are using cloudfront as a load balancer for the assets the URL we generate needs to include the region.

However boto3 does not do this so we are having to make use of the AWS CLI to create this URL.